### PR TITLE
updated docs and add authorization

### DIFF
--- a/chunkmydocs/src/models/server/extract.rs
+++ b/chunkmydocs/src/models/server/extract.rs
@@ -3,17 +3,22 @@ use postgres_types::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use strum_macros::{Display, EnumString};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
-#[derive(Debug, MultipartForm, ToSchema)]
+#[derive(Debug, MultipartForm, ToSchema, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct UploadForm {
-    #[schema(value_type = String, format = "binary")]
+    #[param(style = Form, value_type = TempFile)]
+    #[schema(value_type = TempFile, format = "binary")]
     pub file: TempFile,
+    #[param(style = Form, value_type = Model)]
     #[schema(value_type = Model)]
     pub model: Text<Model>,
+    #[param(style = Form, value_type = Option<i32>)]
     #[schema(value_type = Option<i32>)]
     pub target_chunk_length: Option<Text<i32>>,
-    #[schema(value_type = Option<OcrStrategy>, default = OcrStrategy::default)]
+    #[param(style = Form, value_type = Option<OcrStrategy>)]
+    #[schema(value_type = Option<OcrStrategy>)]
     pub ocr_strategy: Option<Text<OcrStrategy>>,
 }
 

--- a/chunkmydocs/src/routes/task.rs
+++ b/chunkmydocs/src/routes/task.rs
@@ -17,12 +17,15 @@ use uuid::Uuid;
     context_path = "/api/v1",
     tag = "Task",
     params(
-        ("task_id" = Option<String>, Path, description = "Id of the task to get."),
+        ("task_id" = Option<String>, Path, description = "Id of the task to retrieve")
     ),
     responses(
         (status = 200, description = "Detailed information describing the task", body = TaskResponse),
         (status = 500, description = "Internal server error related to getting the task", body = String),
     ),
+    security(
+        ("api_key" = []),
+    )
 )]
 pub async fn get_task_status(
     pool: web::Data<Pool>,
@@ -57,11 +60,14 @@ pub async fn get_task_status(
     path = "/task",
     context_path = "/api/v1",
     tag = "Task",
-    request_body(content = UploadForm, description = "Multipart form encoded data to create an task", content_type = "multipart/form-data"),
+    request_body(content = UploadForm, description = "Multipart form request to create an task", content_type = "multipart/form-data"),
     responses(
         (status = 200, description = "Detailed information describing the task such that it's status can be polled for", body = TaskResponse),
         (status = 500, description = "Internal server error related to creating the task", body = String),
     ),
+    security(
+        ("api_key" = []),
+    )
 )]
 pub async fn create_extraction_task(
     req: HttpRequest,


### PR DESCRIPTION
- **Initial commit**
- **added git.sh**
- **added api examples**
- **updated requirements.txt**
- **skeleton: add turbo monorepo structure**
- **cleanup: package json conflict**
- **feat: added pr-branch.sh**
- **cleanup: remove turbo-ex**
- **cleanup: fixed eslint-rc with @eslin/migrate-config**
- **feature: added ci action for pnpm**
- **feature: finish migration of web to solidjs**
- **admin: testing if review is needed for pr's to be merged**
- **add hsuky attempt 1**
- **feat: prettier is working now potentially**
- **feature: add Rust extraction copy through simple copy**
- **cleanup: Rust extraction crate compilig**
- **bugfix: add missing files**
- **new react base**
- **fixed lockfile**
- **Added pages**
- **feat: added / and /viewer routes**
- **feat: remove plausible, changed CI names**
- **Added radix**
- **cleanup: refactor rust code to remove warnings and use lib**
- **cleanup: add default run**
- **Added radix**
- **Added styled components**
- **feat: added tailwind**
- **bugfix: duplication of files from mac**
- **Updates**
- **Updates**
- **Added cyan color scale classes**
- **Padding passed as prop for button**
- **Fixed up button a bit**
- **feat: added in baseline viewer panels**
- **feature: add utoipa covering health and task routes**
- **updated tailwind.config.cjs**
- **feature: beginning to split both things out**
- **Fixed BetterButton styling and props for active/resting states**
- **Added onClick prop to Betterbutton**
- **added more chunk basics**
- **fix ts error**
- **Padding passed as prop for button**
- **Fixed up button a bit**
- **Updating**
- **Added header on homepage**
- **Fixed up stuff for merging**
- **feature: segmentchunk without the full features**
- **Progress on homepage**
- **feature: create_api_key route**
- **done adding api key**
- **done adding api key**
- **version of prefixedapicontroller**
- **added pdla**
- **added email check, will return api key**
- **Completed homepage static setup and phone sizing**
- **wip: pdf import / dist is out here**
- **cleanup: make local dev viable**
- **feature: add diesel migrations**
- **Reworking segment containers to be accordians**
- **wip: more pdf-js testing. CI is failing, it is still working**
- **mkd.py**
- **chunk and mkd unit test done, need akhil to test**
- **chunk and mkd unit test done, need akhil to test**
- **chunking done**
- **refactored chunking**
- **Static for viewer is completed with Accordian addition. Starting JSON piping**
- **local pg**
- **sending it**
- **rebased**
- **server in runnign state**
- **idk**
- **done with s3 config**
- **server running again**
- **uopdated task_processor**
- **changed python to fast**
- **hella conflicts**
- **storage service removal successful**
- **JSON and Markdown rendering + json piping completed**
- **wip: added react-pdf. Going to A/B test possibly**
- **feat: using react-pdf**
- **feat: making a pdf now**
- **renamed dirs**
- **added docker files**
- **Added design fixes to several things in viewer and credit buttons on hpmaepage**
- **bugfix: mdk**
- **Working in viewer design**
- **feature: pdf boxes working on small mode**
- **pdf boxes are more solid**
- **feature: pdf view with squares works with all screen sizes**
- **updated rust version**
- **error building docker**
- **feature: added libglib2.0-dev**
- **Updates**
- **Completed payload creation from uploading components**
- **Updates**
- **wip: local docker setup**
- **pdla yaml created**
- **chunkmydocs yaml created**
- **task_processor yaml created**
- **rrq yaml created**
- **Added envs to chunkmydocs**
- **Added envs to task_processor**
- **pdla yaml created**
- **chunkmydocs yaml created**
- **task_processor yaml created**
- **rrq yaml created**
- **Added envs to chunkmydocs**
- **Added envs to task_processor**
- **added example secret files**
- **updated example secret files**
- **removed duplicates**
- **added cors**
- **cleanup: fix local dev by correctly spec'ing command for pdla**
- **Additions from ishaan**
- **Updates**
- **Moved things to API key - request to local server hooked up**
- **fixed issues**
- **cleanup: chunkmydocs Dockerfile**
- **feature: add chunkmydocs to docker-compose file**
- **Updates**
- **chunkmydocs build successful**
- **updated docker tag**
- **fixed dockerfile**
- **yaml updated**
- **yaml updated**
- **updated**
- **Update lib.rs**
- **updated docker**
- **deployed**
- **Update README.md**
- **Update README.md**
- **added ssl imports**
- **fixed ssl issues**
- **rembased**
- **updated task processor**
- **pyscripts and deployed**
- **fixed config errors**
- **fixed config errors**
- **Create LICENSE**
- **updated configs**
- **deploying to prod**
- **deployment successful**
- **removed unused file**
- **Status page static completed**
- **Complted static status component**
- **Merging**
- **colors for pdf boxes**
- **udpated model to return input file url too**
- **removed duplicate config**
- **docker compose keycloak up:**
- **metering done. hard coded limit to 100 pages**
- **docker compose keycloak up:**
- **done**
- **no expiration works**
- **metering done. hard coded limit to 100 pages**
- **more metering**
- **usage route**
- **Rebasing with main**
- **Waiting on PDF being sent with PDF data**
- **Added loading states**
- **Semi completed version**
- **Semi completed version**
- **Updates**
- **Starting state lift**
- **Frontend almost done - need to add Auth and make PDF reader feature complete**
- **keycloak under construction**
- **Completed status page with timer**
- **Completed status with looader**
- **keycloak up on kube**
- **Fixed favicon stuff**
- **added pypi package**
- **Potential reset - adding shadcn**
- **Updates**
- **rm unused code**
- **Updates**
- **fixed pdf stuff**
- **rebased**
- **idk**
- **viewer fixed**
- **new trigger**
- **Working on it**
- **Merginf or the day**
- **keycloak set up completed**
- **rebase errors**
- **auth done**
- **pdf2png**
- **i hate pnmp**
- **added .env.example**
- **Updates**
- **Small fix on chevron**
- **Updating and adding auth**
- **pdf2png dodne**
- **axios implemented for unified headers**
- **added pdf2png docker and server**
- **phi35 service**
- **added terraform for GPU VM**
- **working on auth tokens decoding**
- **udpated triggers and tables**
- **Added some auth stuff**
- **fixed up pricing page with auth state**
- **auth middleware up**
- **jsonwebtoken was a fail**
- **token validation succeful**
- **lol**
- **added dockers**
- **phi 35 updateS**
- **requirements**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **requirements.txt**
- **4 bit quantize**
- **4 bit quantize**
- **4 bit quantize**
- **4 bit quantize - new model**
- **4 bit quantize - new model**
- **added examples**
- **fix pdf2png test and added examples**
- **fix pdf2png test and added examples**
- **phi 3.5 vision not very good :(**
- **can download json now from header**
- **added server side rust code to hit pdf2png service**
- **starting to fuck around with pdf worker**
- **finally fixed pdf page count reader**
- **working on it**
- **Fixed ts checks**
- **Fixing ts errors**
- **Added hover for type on segments in pdf - starting on click to go to segment**
- **Completed pdf overlay color fixes**
- **completed click segment to scroll to chunk in viewer**
- **completed click segment to scroll to chunk in viewer**
- **token validation succeful**
- **new migrations added**
- **updated migrations**
- **updated migrations**
- **working on it**
- **v1 of /user**
- **migrations and user route done**
- **create task updated**
- **get task done**
- **added user id check on get task**
- **done with migrations**
- **updated redoc**
- **Working on it**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **updates**
- **Updates**
- **Updates**
- **Updates**
- **fixed presigned url issue**
- **Updates**
- **Updates**
- **fixed task fetching**
- **Updates**
- **Updates**
- **minor edits**
- **added user func**
- **new tables and refactoring**
- **sdtripe routs**
- **tryin gto get stripe working**
- **create customer and intent done**
- **terraform written**
- **terraform updated**
- **terraform for gcp resources completed**
- **added self-deployment.md**
- **added self-deployment.md**
- **updated dockerfiles**
- **added web docker**
- **removed grobid url**
- **removed table ocr url**
- **fixing deployment**
- **deploying web**
- **fixed pyscript models**
- **updated terraform**
- **api**
- **new token**
- **fixing rrq issues**
- **task processor**
- **webhook for stripe**
- **api**
- **new token**
- **task processor**
- **webhook for stripe**
- **stripe webhook and local cli testing**
- **stripe**
- **stripe**
- **stripe**
- **refactor lib**
- **Add .DS_Store to .gitignore**
- **new gitignore**
- **idk**
- **bearer**
- **added rrq on vm**
- **keycloak pgurl updated**
- **fixing rrq issues**
- **added rrq on vm**
- **keycloak pgurl updated**
- **removed sample pdfs**
- **models**
- **fixing git ignore for ds store**
- **Updates**
- **Updates**
- **Updates**
- **Adding payments from frontend working**
- **udpating keycloak ingress**
- **hooking up table_ocr**
- **pdf splliting fixed**
- **pdf splliting fixed**
- **pdf splitting merged**
- **table ocr rolled**
- **pdf service**
- **add pdf service**
- **pdf service docker updated**
- **fixed requirements.txt**
- **deployed succesfully**
- **rebased**
- **admin account creation done**
- **admin account creation done**
- **removed warnings**
- **removed redis from terraform**
- **fixed crontab issues**
- **deployed and working**
- **added table ocr to redoc**
- **idk**
- **new deploy**
- **stable**
- **segments**
- **updated server**
- **deployed**
- **rename**
- **added get tasks**
- **/tasks route done**
- **fixed ts**
- **added OS pdf conversion tooling and updated third party liscences:**
- **added Qwen2-VL-7B-Instruct-AWQ support**
- **adding dev terraform**
- **samples**
- **samples**
- **imports**
- **2B**
- **Refactor chunking logic to handle titles, section headers, and long segments more efficiently. Ignore page headers/footers and ensure logical grouping within target length.**
- **qwen service works**
- **wokring on vnet**
- **working on NAT gateway**
- **vllm**
- **vllm**
- **vllm**
- **changes**
- **batched images tset**
- **batched images test**
- **batch vllm inference**
- **finished batch inference**
- **finished batch inference - added typing**
- **fixing bugs batch**
- **fixing bugs batch**
- **trying out AWQ**
- **test**
- **debugging output**
- **output modles in pyscripts**
- **finished new output, no output url anymore direct json in response body**
- **refactored gcp kube**
- **Flipped**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **Updates**
- **UIpdates**
- **Updates**
- **Updates**
- **deploying frontend**
- **deploying frontend with json instead of file url**
- **added page count and file name:**
- **added indexes for tasks**
- **added indexes for tasks**
- **indexes**
- **rm un-used code**
- **rebasing**
- **updated up.sql**
- **lfg**
- **new prod deployment**
- **Added smart commits and updated .gitignore**
- **redoc error**
- **new comments for redoc**
- **added segment and chunk and segment type to redoc**
- **deploying redocs bug fixes**
- **Removed incomplete pages - deployable**
- **Frontend stable version - cleaned up pages**
- **silent sign in and sign out**
- **silent sign in and sign out fixed**
- **fixed user bug**
- **Merging**
- **Status page theme switched**
- **fixed user bug**
- **Fixed pdf segments tailwind bug**
- **pdf bug fixed**
- **v1 frontend completed**
- **v1 frontend completed**
- **v1 of frontend completed**
- **v1 of frontend completed**
- **removing console.logs**
- **fixing assets bug**
- **pushed changes**
- **refactoring yaml files**
- **rm table ocr from redoc**
- **deploying redoc bug fix**
- **updating dpeloment**
- **fixed react img import bug**
- **"Refactored tasks and added pipeline configuration"**
- **"Refactored tasks and added pipeline configuration"**
- **"Refactored task and added pipeline configuration"**
- **"Refactored task and added pipeline configuration"**
- **docker update**
- **new domain deployment successful**
- **optmized background image**
- **working on runtime env for vite**
- **still trying to set env vars**
- **updated dockerimage**
- **working on it**
- **dynamic env works**
- **updated web deployment**
- **udpated dockerimage**
- **deployed to prod**
- **deploying redoc bug fix**
- **deploying redoc bug fix**
- **updating dpeloment**
- **updating dpeloment**
- **fixed react img import bug**
- **fixed react img import bug**
- **docker update**
- **docker update**
- **new domain deployment successful**
- **new domain deployment successful**
- **optmized background image**
- **optmized background image**
- **working on runtime env for vite**
- **working on runtime env for vite**
- **still trying to set env vars**
- **still trying to set env vars**
- **updated dockerimage**
- **updated dockerimage**
- **working on it**
- **working on it**
- **dynamic env works**
- **dynamic env works**
- **updated web deployment**
- **updated web deployment**
- **udpated dockerimage**
- **udpated dockerimage**
- **deployed to prod**
- **deployed to prod**
- **refactored**
- **refactored**
- **base**
- **base**
- **more stripe funcs**
- **more stripe funcs**
- **updates to terraform and secrets**
- **fixing models**
- **bentoml server running for images**
- **working on ocr**
- **working on paddle ocr**
- **working on paddle ocr**
- **merging**
- **bento ml syntax error**
- **in CUDA hell**
- **lfg**
- **trying png files**
- **image reading error**
- **suck in deps hell**
- **suck in deps hell**
- **optimizing ocr**
- **adding reading order to ocr**
- **adding reading order to ocr**
- **adding reading order to ocr**
- **paddleocr reading order**
- **word box**
- **working on implementing**
- **task service started**
- **batching paddle ocr**
- **table ocr using PPStructure**
- **table ocr using PPStructure**
- **visualizing tabe ocr**
- **visualizing tabe ocr**
- **table ocr, rows and cols**
- **table ocr, rows and cols**
- **deploying new task processor**
- **deploying new chunkmydocs**
- **updated structure model**
- **experimenting with settings**
- **experimenting with settings**
- **experimenting with settings**
- **experimenting with ocr bs structure**
- **table ocr and ocr working**
- **adding models**
- **model seralizatino incorrect**
- **adding text to the table output**
- **consolidated ocr results**
- **consolidated ocr results**
- **model error fixed**
- **model error fixed**
- **model error fixed**
- **adding latex**
- **latex bug**
- **latex bug**
- **latex bug**
- **latex bug**
- **latex bug**
- **fixing random bug**
- **latex was mid, trying different model**
- **latex inference error**
- **dependencies issues**
- **removing latex**
- **removing latex**
- **image magikc fixes**
- **pdf permission errors**
- **pdf permission errors**
- **pdf permission errors -> updating policy**
- **updating policy errors**
- **updating policy errors**
- **updating policy errors**
- **isntalled magick 7**
- **installed magick 7**
- **working on paddle ocr**
- **processing segments**
- **processing segments**
- **interservice communicatino error**
- **iamge path  error**
- **segmeents [] after processing**
- **file path issues**
- **iamges are base64 strs**
- **images are base64 strs**
- **updated crop image function**
- **debugging**
- **converted image paths from str to Path**
- **image cropping issues**
- **image cropping issues**
- **image cropping issues**
- **updating str to bytepath**
- **fixing path errors**
- **ocr issues, adding fallback**
- **ocr issues, adding fallback**
- **adding multiprocessing**
- **removing multiprocessing**
- **removed debug statements**
- **error management**
- **using image magick to convert**
- **fixed paging issue**
- **increasing segment bbox size**
- **bug fix**
- **math mistake**
- **mergeing**
- **new pdf2img**
- **service URL**
- **service url**
- **added image magick to startup.sh**
- **added image magick to startup.sh with openCL**
- **ppocr has spelling mistakes**
- **making text detection optiona;**
- **adding spell check on ocr**
- **ocr not going brr**
- **updating pyhton syntax error**
- **pdla patch**
- **new pdf to png**
- **imporoved spell check**
- **fixed gpu dependencies**
- **syntax error**
- **added pdla secret**
- **udpated project.toml**
- **udpated project.toml**
- **udpated project.toml**
- **udpated project.toml**
- **adding optional value to pdf to iamg**
- **updating example**
- **new pdla patch**
- **density before file in image magikc**
- **scale factor added**
- **scale factor added**
- **pdla density**
- **density**
- **new attempt at pdf page mem error**
- **new attempt at pdf page mem error**
- **convert from path**
- **deploying pdla**
- **changing pdla default value**
- **changing pdla default value**
- **dev gpu terraform**
- **updated vars for vm**
- **tf - new**
- **tf - new**
- **new compose**
- **added new docker compose**
- **added new docker compose**
- **added new docker compose gpu runtime**
- **testing without spell check**
- **added new docker compose gpu runtime**
- **updated terraform**
- **new config**
- **threadlock**
- **adding multiprocessing for ocr**
- **increasing max workers**
- **trying muliprocessing**
- **pickle error**
- **pickle error**
- **no multiporcessing on gpu**
- **no multiporcessing on gpu**
- **parrellel gpu processing**
- **using threadpool executor**
- **using threadpool executor**
- **issues with Tensor**
- **adding threading locks**
- **pdla maxxed**
- **multiprocessing cropping issue**
- **multiprocessing cropping issue**
- **pydantic error**
- **merged with main**
- **pydantic errors**
- **new models**
- **output is not in order**
- **added ocr strategy**
- **fixed syntax error**
- **only cropping if needed**
- **only cropping if needed**
- **hierarchical content**
- **iamgemagick gpu support**
- **iamgemagick gpu support**
- **syntax error fix**
- **timing it**
- **adding gpu acceleration**
- **using convert**
- **barely any difference**
- **adding latex**
- **adding latex ocr**
- **fixed sytax error**
- **img**
- **formula ocr optional**
- **added eta**
- **removing debug logs**
- **lang set for table ocr**
- **cleaning up, removed latex ocr (too slow and sucks)**
- **cleaning up unused deps**
- **cleaning up unused deps**
- **ocr issues**
- **ocr issues**
- **ocr issues**
- **ready to be used by the rest of the systems**
- **connecting teask_processor**
- **no more mkd**
- **parallelization increase**
- **rust implementation done**
- **stripe**
- **clean up**
- **segment_type error**
- **seralization issue**
- **seralization issue**
- **segment_type missing error**
- **fixed syntax error**
- **Fixed polling issue for task status viewer**
- **checking ocr_strat**
- **checking ocr_strat**
- **markdown bug**
- **syntax error**
- **syntax error**
- **model hell**
- **html to mkd**
- **done with new task processing**
- **tasks searlization error fixed.**
- **fixed task count**
- **new task count**
- **pdf to image**
- **extension error**
- **cropping error**
- **getting iamges back, not working**
- **.**
- **pyscripts**
- **fixed scaling factor for page**
- **new compose**
- **scaling factor issues**
- **fixed pdla deploy**
- **added image url stuff :**
- **added image url stuff**
- **task creation has image_url**
- **rm threadlock and run in threadpool in pdla**
- **image file path fixes**
- **s3 upload issues**
- **done with ocr**
- **get tasks error fixed**
- **process lock on / route**
- **Refactored frontend**
- **Rebased with main succesfully**
- **Added OCR strategy and Task stats in viewer & status view**
- **main test**
- **removed segment density**
- **Moved dashboard to pages**
- **Added curl command placeholder for no tasks**
- **deployed new pdla**
- **added timing for ocr**
- **added timing for ocr**
- **table html to mkd**
- **table html to mkd**
- **table html to mkd**
- **Cleaned up svg errors, added oCR slection on upload form, images optimized**
- **fixing  mkd table issue**
- **fixing  mkd table issue**
- **adding \n as string literal**
- **adding \n as string literal**
- **| is not |?**
- **doing it on frontend**
- **doing it on frontend**
- **base**
- **frontend markdown resolved**
- **Rebasing with main**
- **Added tables markdown css, html viewing options, API key fixes for small screen menu dropdown**
- **updated google timeout**
- **list item fixes**
- **list item ol start from give digit**
- **clean ul**
- **migrations**
- **new migs**
- **new api**
- **new api spec**
- **wiping pg**
- **updating gpu**
- **updated gpu**
- **separated out task workers**
- **new workers - fast - highquality**
- **cleaned up pyscripts**
- **refactoring the models**
- **syntax error fix**
- **fixed syntax error**
- **fixed syntax error**
- **fixed pyscripts**
- **new dockers for processors**
- **new processor names**
- **cleanup**
- **Need to add chunking strategy in upload form**
- **Updating with main**
- **Added HTML viewing fixes and chunking strategy button on upload form**
- **No tasks state text prompt added**
- **task service docker created**
- **docker updated**
- **docker updated**
- **docker updated**
- **added uv venv**
- **added uv venv**
- **new kube**
- **paddle ocr issue**
- **created init**
- **paddle ocr issues, going to build with gpu**
- **added libgomp1 to dockerfile**
- **added openCV deps in docker**
- **updated num of workers**
- **repushing**
- **new kube**
- **unexpected end of data error**
- **dockerfile updated becuase cudnn error**
- **new kube**
- **updated env for docker image**
- **dockerignore update**
- **docker image inly copying over essentials**
- **docker image inly copying over essentials**
- **fixed COPY**
- **kube**
- **deploying new frontend**
- **task ocr parsed to float**
- **get content updated**
- **prints**
- **idek**
- **ready for deployment**
- **deploying new version**
- **deploying new version**
- **deploymetn with ocr**
- **deployment successful**
- **new cmds**
- **Fixed bug for API pricing calculator - fast pricing is now correct**
- **updated api spec**
- **added authorization**
