### PR TITLE
docs(README): fix incorrect git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ https://docs.chunkr.ai
 
 2. Deploy:
    ```bash
-   git clone https://github.com/luminainc/chunkr
+   git clone https://github.com/lumina-ai-inc/chunkr
    cd chunkr
    cp .env.example .env
    docker compose up -d


### PR DESCRIPTION
Fixes #256

Update the git URL in the root `README.md` file.

* Change the git URL in the "Quick Start with Docker Compose" section from `https://github.com/luminainc/chunkr` to `https://github.com/lumina-ai-inc/chunkr`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lumina-ai-inc/chunkr/issues/256?shareId=XXXX-XXXX-XXXX-XXXX).