### PR TITLE
Fix: make main usable by fixing build dependencies and Postgres mount issues 

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -118,7 +118,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 10s

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,7 +46,7 @@ memtrack = { version = "0.3.0", optional = true }
 mime = "0.3.17"
 once_cell = "1.19.0"
 openssl = "0.10.66"
-pdfium-render = "=0.8.31"
+pdfium-render = "=0.8.36"
 postgres-openssl = "0.5.0"
 postgres-types = { version = "0.2.7", features = [
   "derive",

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87-slim-bookworm AS chef
+FROM rust:1.88-slim-bookworm AS chef
 RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev g++ curl libglib2.0-dev
 RUN cargo install cargo-chef
 WORKDIR /app

--- a/docker/task/Dockerfile
+++ b/docker/task/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87-slim-bookworm AS chef
+FROM rust:1.88-slim-bookworm AS chef
 RUN apt-get update -y && apt-get -y install pkg-config libssl-dev libpq-dev g++ curl libglib2.0-dev
 RUN cargo install cargo-chef
 WORKDIR /app


### PR DESCRIPTION
There were a few issues on main that prevented me from being able to run the application.
1. `core` would not compile because the rust version was out of date.
2. Also, `pdfium-render` was outdated and would not compile anymore.
3. Postgres 18+ had issues with mounting the `data` directory

This PR fixes all the above issues and provides a working version of main.

Note: This PR supersedes #580 